### PR TITLE
Fix ragged attention mask and cache bookkeeping

### DIFF
--- a/gemma_jax/core/model.py
+++ b/gemma_jax/core/model.py
@@ -150,7 +150,7 @@ class AttentionConfig:
     query_pre_attn_scalar: float
     rope_base_frequency: int = DEFAULT_ROPE_BASE_FREQUENCY
     rope_scale_factor: float = DEFAULT_ROPE_SCALE_FACTOR
-    window_size: int = 0 #  | None = None
+    window_size: int = 0  # 0 disables sliding-window masking
     cache_length: int = 1024
     use_ragged_attention: bool = True
     mesh: Optional[Mesh] = None  # Add mesh to config
@@ -480,7 +480,11 @@ def self_attention(
     cache_key, cache_value, lookup_mask = cache.lookup_layer(
         seg_info_for_lookup,  # Use the advanced seg_info here
         layer=layer_idx,
-        window=layer_config.window_size if attn_type == AttentionType.LOCAL_SLIDING else None,
+        window=(
+            layer_config.window_size
+            if attn_type == AttentionType.LOCAL_SLIDING and layer_config.window_size > 0
+            else None
+        ),
         query_positions=query_positions,
     )
 
@@ -500,16 +504,20 @@ def self_attention(
     query_scaled = query * layer_config.query_pre_attn_scalar
 
     # Determine if we should use ragged attention for variable-length sequences
-    use_ragged = ragged and hasattr(layer_config, 'use_ragged_attention') and layer_config.use_ragged_attention
+    use_ragged = (
+        ragged
+        and attn_type != AttentionType.LOCAL_SLIDING
+        and getattr(layer_config, 'use_ragged_attention', False)
+    )
     
     if use_ragged:
-        # Use sequence lengths from SegmentInfo for ragged attention
-        # This eliminates padding overhead for variable-length sequences
+        # Use sequence lengths from ``seg_info_for_lookup`` so the newly written
+        # token can attend to itself.
         attn_out = multi_head_attention(
             query_scaled.astype(jnp.float32),
             cache_key.astype(jnp.float32),
             cache_value.astype(jnp.float32),
-            seg_info.lengths,  # Pass sequence lengths for ragged attention
+            seg_info_for_lookup.lengths,
             use_fused_kernel=True,
             use_ragged_attention=True,
         ).astype(x.dtype)


### PR DESCRIPTION
## Summary
- correct ragged self-attention call to use lengths after cache update
- disable ragged path for LOCAL_SLIDING layers
- treat window size 0 as no sliding window
- fix cache bookkeeping so counters update once per step
- test ring buffer bookkeeping behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68604300fcd4832fb6451cbe42d0a23d